### PR TITLE
Fix issue #4 - posts retrieving

### DIFF
--- a/routes/util.go
+++ b/routes/util.go
@@ -37,24 +37,20 @@ func GetThemeCookie(c *fiber.Ctx) string {
 
 func GetActorPost(ctx *fiber.Ctx, path string) error {
 	obj := activitypub.ObjectBase{Id: config.Domain + path}
-	collection, err := obj.GetCollectionFromPath()
+	post, err := obj.GetFromPath()
 
 	if err != nil {
 		return Send404(ctx, "Post not found", util.MakeError(err, "GetActorPost"))
 	}
 
-	if len(collection.OrderedItems) > 0 {
-		enc, err := json.MarshalIndent(collection, "", "\t")
-		if err != nil {
-			return Send500(ctx, "Failed to get thread", util.MakeError(err, "GetActorPost"))
-		}
-
-		ctx.Response().Header.Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"")
-		_, err = ctx.Write(enc)
-		return util.MakeError(err, "GetActorPost")
+	enc, err := json.MarshalIndent(post, "", "\t")
+	if err != nil {
+		return Send500(ctx, "Failed to get post", util.MakeError(err, "GetActorPost"))
 	}
 
-	return nil
+	ctx.Response().Header.Set("Content-Type", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"")
+	_, err = ctx.Write(enc)
+	return util.MakeError(err, "GetActorPost")
 }
 
 func ParseOutboxRequest(ctx *fiber.Ctx, actor activitypub.Actor) error {


### PR DESCRIPTION
Activity streams spec clearly indicates that Note should return a single entry, not a collection.
This patch makes `GetActorPost()` return a single element by id.

See: https://www.w3.org/TR/activitystreams-vocabulary/#dfn-note
Issue https://github.com/anomalous69/FChannel/issues/4